### PR TITLE
feat: добавлены стандартные бакеты для гистограмм длительности и разм…

### DIFF
--- a/docs/opentelemetry-metrics.md
+++ b/docs/opentelemetry-metrics.md
@@ -60,37 +60,15 @@ client := httpclient.New(httpclient.Config{
 }, "my-client")
 ```
 
-## Настройка бакетов гистограмм
+## Бакеты гистограмм
 
-В отличие от Prometheus, OpenTelemetry не задает бакеты гистограмм в коде библиотеки. Вместо этого используются Views:
+Библиотека автоматически задает бакеты для всех гистограмм в обоих провайдерах (Prometheus и OpenTelemetry), обеспечивая согласованность метрик.
 
-```go
-import (
-    "go.opentelemetry.io/otel/sdk/metric"
-    "go.opentelemetry.io/otel/sdk/metric/metricdata"
-)
+**Бакеты для длительности запросов** (`http_client_request_duration_seconds`):
+`0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2, 3, 5, 7, 10, 13, 16, 20, 25, 30, 40, 50, 60` секунд
 
-// Настройка бакетов для гистограммы длительности запросов
-view := metric.NewView(
-    metric.Instrument{
-        Name: "http_client_request_duration_seconds",
-        Kind: metric.InstrumentKindHistogram,
-    },
-    metric.Stream{
-        Aggregation: metric.AggregationExplicitBucketHistogram{
-            Boundaries: []float64{
-                0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5,
-                1, 2, 3, 5, 7, 10, 13, 16, 20, 25, 30, 40, 50, 60,
-            },
-        },
-    },
-)
-
-meterProvider := sdkmetric.NewMeterProvider(
-    sdkmetric.WithView(view),
-    sdkmetric.WithReader(exporter),
-)
-```
+**Бакеты для размеров** (`http_client_request_size_bytes`, `http_client_response_size_bytes`):
+`256, 1024, 4096, 16384, 65536, 262144, 1048576, 4194304, 16777216` байт
 
 ## Кастомный Prometheus Registry
 

--- a/examples/otel_metrics/main.go
+++ b/examples/otel_metrics/main.go
@@ -56,16 +56,5 @@ func main() {
 
 	fmt.Println("Метрики успешно записаны в OpenTelemetry!")
 	fmt.Println("Для просмотра метрик настройте OpenTelemetry SDK с подходящим экспортером.")
-	fmt.Println()
-	fmt.Println("Пример настройки бакетов гистограмм через Views:")
-	fmt.Println(`
-	view.New(view.Instrument{
-		Name: "http_client_request_duration_seconds",
-		Kind: view.InstrumentKindHistogram,
-	}, view.Stream{
-		Aggregation: view.AggregationExplicitBucketHistogram{
-			Boundaries: []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10},
-		},
-	})
-	`)
+	fmt.Println("Бакеты гистограмм задаются автоматически и одинаковы для Prometheus и OpenTelemetry.")
 }

--- a/metrics_otel.go
+++ b/metrics_otel.go
@@ -58,18 +58,21 @@ func NewOpenTelemetryMetricsProvider(clientName string, mp metric.MeterProvider)
 			MetricRequestDuration,
 			metric.WithDescription("HTTP client request duration in seconds"),
 			metric.WithUnit("s"),
+			metric.WithExplicitBucketBoundaries(DefaultDurationBuckets...),
 		)
 
 		reqSize, _ := meter.Float64Histogram(
 			MetricRequestSizeBytes,
 			metric.WithDescription("HTTP client request size in bytes"),
 			metric.WithUnit("By"),
+			metric.WithExplicitBucketBoundaries(DefaultSizeBuckets...),
 		)
 
 		respSize, _ := meter.Float64Histogram(
 			MetricResponseSizeBytes,
 			metric.WithDescription("HTTP client response size in bytes"),
 			metric.WithUnit("By"),
+			metric.WithExplicitBucketBoundaries(DefaultSizeBuckets...),
 		)
 
 		inflight, _ := meter.Int64UpDownCounter(

--- a/metrics_prometheus.go
+++ b/metrics_prometheus.go
@@ -50,12 +50,9 @@ func NewPrometheusMetricsProvider(clientName string, reg prometheus.Registerer) 
 			),
 			RequestDuration: prometheus.NewHistogramVec(
 				prometheus.HistogramOpts{
-					Name: MetricRequestDuration,
-					Help: "HTTP client request duration in seconds",
-					Buckets: []float64{
-						0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5,
-						1, 2, 3, 5, 7, 10, 13, 16, 20, 25, 30, 40, 50, 60,
-					},
+					Name:    MetricRequestDuration,
+					Help:    "HTTP client request duration in seconds",
+					Buckets: DefaultDurationBuckets,
 				},
 				[]string{"client_name", "method", "host", "status", "attempt"},
 			),
@@ -75,21 +72,17 @@ func NewPrometheusMetricsProvider(clientName string, reg prometheus.Registerer) 
 			),
 			RequestSize: prometheus.NewHistogramVec(
 				prometheus.HistogramOpts{
-					Name: MetricRequestSizeBytes,
-					Help: "HTTP client request size in bytes",
-					Buckets: []float64{
-						256, 1024, 4096, 16384, 65536, 262144, 1048576, 4194304, 16777216,
-					},
+					Name:    MetricRequestSizeBytes,
+					Help:    "HTTP client request size in bytes",
+					Buckets: DefaultSizeBuckets,
 				},
 				[]string{"client_name", "method", "host"},
 			),
 			ResponseSize: prometheus.NewHistogramVec(
 				prometheus.HistogramOpts{
-					Name: MetricResponseSizeBytes,
-					Help: "HTTP client response size in bytes",
-					Buckets: []float64{
-						256, 1024, 4096, 16384, 65536, 262144, 1048576, 4194304, 16777216,
-					},
+					Name:    MetricResponseSizeBytes,
+					Help:    "HTTP client response size in bytes",
+					Buckets: DefaultSizeBuckets,
 				},
 				[]string{"client_name", "method", "host", "status"},
 			),

--- a/metrics_provider.go
+++ b/metrics_provider.go
@@ -12,6 +12,17 @@ const (
 	MetricResponseSizeBytes = "http_client_response_size_bytes"
 )
 
+// DefaultDurationBuckets содержит бакеты по умолчанию для гистограмм длительности запросов (в секундах).
+var DefaultDurationBuckets = []float64{
+	0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5,
+	1, 2, 3, 5, 7, 10, 13, 16, 20, 25, 30, 40, 50, 60,
+}
+
+// DefaultSizeBuckets содержит бакеты по умолчанию для гистограмм размеров запросов и ответов (в байтах).
+var DefaultSizeBuckets = []float64{
+	256, 1024, 4096, 16384, 65536, 262144, 1048576, 4194304, 16777216,
+}
+
 // MetricsProvider определяет интерфейс для различных бэкендов метрик.
 type MetricsProvider interface {
 	// RecordRequest записывает метрику запроса
@@ -43,6 +54,6 @@ type MetricsProvider interface {
 type MetricsBackend string
 
 const (
-	MetricsBackendPrometheus     MetricsBackend = "prometheus"
-	MetricsBackendOpenTelemetry  MetricsBackend = "otel"
+	MetricsBackendPrometheus    MetricsBackend = "prometheus"
+	MetricsBackendOpenTelemetry MetricsBackend = "otel"
 )


### PR DESCRIPTION
…еров запросов

- В metrics_provider.go добавлены переменные DefaultDurationBuckets и DefaultSizeBuckets для использования в гистограммах.
- Обновлены Prometheus и OpenTelemetry провайдеры для использования новых бакетов.
- Документация обновлена для отражения автоматической настройки бакетов в обоих провайдерах.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce default duration/size histogram buckets, use them in Prometheus and OpenTelemetry providers, and update docs/examples to reflect automatic, consistent buckets.
> 
> - **Metrics**:
>   - Add `DefaultDurationBuckets` and `DefaultSizeBuckets` in `metrics_provider.go`.
>   - Prometheus: use defaults for `RequestDuration`, `RequestSize`, and `ResponseSize` histograms in `metrics_prometheus.go`.
>   - OpenTelemetry: set explicit bucket boundaries for duration and size histograms using defaults in `metrics_otel.go`.
> - **Docs/Examples**:
>   - `docs/opentelemetry-metrics.md`: document automatic, consistent histogram buckets for both providers and list boundaries; remove Views-based configuration.
>   - `examples/otel_metrics/main.go`: update output to note automatic, unified buckets.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 33387f27dcc9bc5c28d6509947cfa03e0575792a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->